### PR TITLE
Component bitset

### DIFF
--- a/scripts/play.lua
+++ b/scripts/play.lua
@@ -86,7 +86,8 @@ end
 function onCollide(thisId, secondId)
 	--entities[secondId]:scale(0.5, 0.5)
 	playSound("boom")
-	addParticleEmitter(entities[secondId]:getX(), entities[secondId]:getY(), "fire")
+	-- MASSIVE FPS DROPS HERE
+	--addParticleEmitter(entities[secondId]:getX(), entities[secondId]:getY(), "fire")
 	-- if object:type() == "enemy" then
 		-- player:damage(10)
 	-- end

--- a/src/Collision.hpp
+++ b/src/Collision.hpp
@@ -47,76 +47,76 @@ namespace Vigilant {
                 return true;
             }
 
-			//static bool checkEntityOnEntityCollision(Entity* actor, const std::vector<std::shared_ptr<Entity>>& entities) {
-				//return false;
-			//}
+            //static bool checkEntityOnEntityCollision(Entity* actor, const std::vector<std::shared_ptr<Entity>>& entities) {
+                //return false;
+            //}
 
             static void checkProjectileEntityCollision(Entity* projectile, const std::vector<Entity*> entities) {
-            	// Sane as playerEntityCollision but need to call event not for entity, but Entity* shooter
-				// This is tempporary because lua wont know if player collided with entity or players projectile
-				// Also npcs will not be able to create projectiles themselves
-				Entity* owner = projectile->getComponent<ProjectileComponent>()->getShooter();
-				auto sprite = projectile->getComponent<SpriteComponent>();
-				SDL_Rect collider{
-					int(projectile->transform->getX()),
-					int(projectile->transform->getY()),
-					int(sprite->getWidth() * owner->transform->getScaleX()),
-					int(sprite->getHeight() * owner->transform->getScaleY())
-				};
+                // Sane as playerEntityCollision but need to call event not for entity, but Entity* shooter
+                // This is tempporary because lua wont know if player collided with entity or players projectile
+                // Also npcs will not be able to create projectiles themselves
+                Entity* owner = projectile->getComponent<ProjectileComponent>()->getShooter();
+                auto sprite = projectile->getComponent<SpriteComponent>();
+                SDL_Rect collider{
+                    int(projectile->transform->getX()),
+                    int(projectile->transform->getY()),
+                    int(sprite->getWidth() * owner->transform->getScaleX()),
+                    int(sprite->getHeight() * owner->transform->getScaleY())
+                };
 
                 for (auto &entity : entities) {
                     // Projectile won't collide with other projectiles or player for now
                     if (entity->hasComponent<ProjectileComponent>() || entity->hasComponent<InputComponent>())
                         continue;
 
-                	auto entityCollider = entity->getComponent<ColliderComponent>();
-                	auto entitySprite = entity->getComponent<SpriteComponent>();
-                	if (entityCollider == 0 || entitySprite == 0)
-                		continue;
+                    auto entityCollider = entity->getComponent<ColliderComponent>();
+                    auto entitySprite = entity->getComponent<SpriteComponent>();
+                    if (entityCollider == 0 || entitySprite == 0)
+                        continue;
 
-					// BROAD PHASE on X axis only
-					if (entity->transform->getX() > projectile->transform->getX() + sprite->getWidth() * projectile->transform->getScaleX() ||
-							entity->transform->getX() + entitySprite->getWidth() * entity->transform->getScaleX() < projectile->transform->getX()) {
-						continue;
-					}
+                    // BROAD PHASE on X axis only
+                    if (entity->transform->getX() > projectile->transform->getX() + sprite->getWidth() * projectile->transform->getScaleX() ||
+                            entity->transform->getX() + entitySprite->getWidth() * entity->transform->getScaleX() < projectile->transform->getX()) {
+                        continue;
+                    }
 
-					// NARROW PHASE
-					if(AABB(collider, entityCollider->getCollider())) {
-						std::cout << "Projectile and entity collision detected" << std::endl;
-						std::string listener = owner->getComponent<ColliderComponent>()->getListener();
-						ScriptEngine::Instance()->onCollide(listener, owner->id->get(), entity->id->get());
-					}
-				}
-			}
-			//static void checkPlayerEntityCollision(Entity* player, const std::vector<Entity*> entities) {
-				//if (checkEntityOnEntityCollision(player, entities)) {
-				//}
-			//}
+                    // NARROW PHASE
+                    if(AABB(collider, entityCollider->getCollider())) {
+                        std::cout << "Projectile and entity collision detected" << std::endl;
+                        std::string listener = owner->getComponent<ColliderComponent>()->getListener();
+                        ScriptEngine::Instance()->onCollide(listener, owner->id->get(), entity->id->get());
+                    }
+                }
+            }
+            //static void checkPlayerEntityCollision(Entity* player, const std::vector<Entity*> entities) {
+                //if (checkEntityOnEntityCollision(player, entities)) {
+                //}
+            //}
 
             static void checkPlayerEntityCollision(Entity* player, const std::vector<Entity*>& entities) {
-				auto playerCollider = player->getComponent<ColliderComponent>();
-				auto playerSprite = player->getComponent<SpriteComponent>();
+                auto playerCollider = player->getComponent<ColliderComponent>();
+                auto playerSprite = player->getComponent<SpriteComponent>();
 
                 for (auto &entity : entities) {
                     // Player won't collide with himself or any projectiles for now
                     if(entity->hasComponent<InputComponent>() || entity->hasComponent<ProjectileComponent>())
                         continue;
 
-					auto collider = entity->getComponent<ColliderComponent>();
-					auto sprite = entity->getComponent<SpriteComponent>();
+                    auto collider = entity->getComponent<ColliderComponent>();
+                    auto sprite = entity->getComponent<SpriteComponent>();
 
-					if (collider && sprite) {
-						// BROAD PHASE
-						// Try to dismiss some entities earlier for performance?
-						// This dumb check I made surprisingly fixes performance lag caused by calling this method with entities
-						// created from Lua and held by EntityManager
-						if (entity->transform->getX() > player->transform->getX() + playerSprite->getWidth() * player->transform->getScaleX() ||
-							entity->transform->getX() + sprite->getWidth() * entity->transform->getScaleX() < player->transform->getX()) {
-							continue;
-						}
+                    if (collider && sprite) {
+                        // BROAD PHASE
+                        // Try to dismiss some entities earlier for performance?
+                        // This dumb check I made surprisingly fixes performance lag caused by calling this method with entities
+                        // created from Lua and held by EntityManager
+                        if (entity->transform->getX() > player->transform->getX() + playerSprite->getWidth() * player->transform->getScaleX() ||
+                            entity->transform->getX() + sprite->getWidth() * entity->transform->getScaleX() < player->transform->getX()) {
+                            continue;
+                        }
 
-						// NARROW PHASE
-						if(AABB(playerCollider->getCollider(), collider->getCollider())) {
+                        // NARROW PHASE
+                        if(AABB(playerCollider->getCollider(), collider->getCollider())) {
                             // Resolve rigid bodies
                             // TODO: need better algorithm here, also player affects entity, but entity also should affect
                             // player because currently player will just fly through entity,
@@ -124,33 +124,33 @@ namespace Vigilant {
                             auto playerBody = player->getComponent<PhysicsComponent>();
                             auto entityBody = entity->getComponent<PhysicsComponent>();
                             if (entityBody) {
-								// 1st try, horrible, player is not affected at all here
-								entityBody->applyForceX(playerBody->getAccelerationX() * playerBody->getMass());
-								entityBody->applyForceY(playerBody->getAccelerationY() * playerBody->getMass());
+                                // 1st try, horrible, player is not affected at all here
+                                entityBody->applyForceX(playerBody->getAccelerationX() * playerBody->getMass());
+                                entityBody->applyForceY(playerBody->getAccelerationY() * playerBody->getMass());
 
-								// 2nd try using 1D Newtonian Elastic Collision
+                                // 2nd try using 1D Newtonian Elastic Collision
                                 // m1v11 * m2v21 = m1v12 * m2v22
                                 // v12 = (m1 - m2)(m1 + m2)*v11 + 2m2/(m1+m2)*v2
                                 // v22 = 2m1/(m1 + m2)*v11 + (m2 - m1)/(m1+m2)*v2
-								// Velocity after collision
+                                // Velocity after collision
                                 //Vector2D nPVelocity = (pMass - eMass) / (pMass + eMass) * pVelocity + (2 * eMass) / (pMass + eMass) * eVelocity;
                                 //Vector2D nEVelocity = (2 * pMass) / (pMass + eMass) * pVelocity + (pMass - eMass) / (pMass + eMass) * eVelocity;
-								//playerBody->setVelocity(pNewVelocity);
-								//entityBody->setVelocity(eNewVelocity);
+                                //playerBody->setVelocity(pNewVelocity);
+                                //entityBody->setVelocity(eNewVelocity);
 
                                 // 3rd try
-								//Vector2D finalVelocity = playerBody->getVelocity() * playerBody->getMass();
-								//finalVelocity /= (playerBody->getMass() + entityBody->getMass());
-								// Does not do anything at all it seems
-								//playerBody->setVelocity(finalVelocity);
-								//entityBody->setVelocity(finalVelocity);
-							}
+                                //Vector2D finalVelocity = playerBody->getVelocity() * playerBody->getMass();
+                                //finalVelocity /= (playerBody->getMass() + entityBody->getMass());
+                                // Does not do anything at all it seems
+                                //playerBody->setVelocity(finalVelocity);
+                                //entityBody->setVelocity(finalVelocity);
+                            }
 
-							// std::cout << "Player and entity collision detected" << std::endl;
-							std::string listener = playerCollider->getListener();
-							ScriptEngine::Instance()->onCollide(listener, player->id->get(), entity->id->get());
-						}
-					}
+                            // std::cout << "Player and entity collision detected" << std::endl;
+                            std::string listener = playerCollider->getListener();
+                            ScriptEngine::Instance()->onCollide(listener, player->id->get(), entity->id->get());
+                        }
+                    }
 
                 }
             }
@@ -164,14 +164,14 @@ namespace Vigilant {
                 auto projectile = entity->getComponent<ProjectileComponent>();
                 int origX, origY;
                 if (physics) {
-					origX = physics->getPreviousPosition().getX();
-					origY = physics->getPreviousPosition().getY();
-				} else if (projectile) {
-					origX = entity->transform->getX();
-					origY = entity->transform->getY();
-				} else {
-					return;
-				}
+                    origX = physics->getPreviousPosition().getX();
+                    origY = physics->getPreviousPosition().getY();
+                } else if (projectile) {
+                    origX = entity->transform->getX();
+                    origY = entity->transform->getY();
+                } else {
+                    return;
+                }
                 // Projectiles: Sprite, Collider, Projectile
                 // Actors: Sprite, Collider, Physics
                 if ( sprite == 0 || collider == 0) {
@@ -201,16 +201,16 @@ namespace Vigilant {
                     }
 
                     if (entityX > 0 && entityY > 0) {
-						// FIXME: collision only works if going down or to the left so if velocity is positive
+                        // FIXME: collision only works if going down or to the left so if velocity is positive
                         if (velocityX >= 0 || velocityY >= 0) {
                             tileColumn = ((entityX + width) / (tileLayer->getTileSize() * tileLayer->getScale()));
                             tileRow = ((entityY + height) / (tileLayer->getTileSize() * tileLayer->getScale()));
-							if (tileRow < tileLayer->getMapHeight() && tileColumn < tileLayer->getMapWidth())
+                            if (tileRow < tileLayer->getMapHeight() && tileColumn < tileLayer->getMapWidth())
                                 tileid = tiles[tileRow][tileColumn];
                         } else if(velocityX < 0 || velocityY < 0) {
                             tileColumn = entityX / (tileLayer->getTileSize() * tileLayer->getScale());
                             tileRow = entityY / (tileLayer->getTileSize() * tileLayer->getScale());
-							if (tileRow < tileLayer->getMapHeight() && tileColumn < tileLayer->getMapWidth())
+                            if (tileRow < tileLayer->getMapHeight() && tileColumn < tileLayer->getMapWidth())
                                 tileid = tiles[tileRow][tileColumn];
                         }
                     }
@@ -221,7 +221,7 @@ namespace Vigilant {
                         entity->transform->setY(origY);
                         // Reversing velocities is not a good solution for collision resolution
                         if (physics) {
-						    entity->getComponent<PhysicsComponent>()->setVelocityX(0);
+                            entity->getComponent<PhysicsComponent>()->setVelocityX(0);
                             entity->getComponent<PhysicsComponent>()->setVelocityY(0);
                         } else if (projectile) {
                             entity->destroy(); // Destroy projectiles so that they don't go through walls

--- a/src/Collision.hpp
+++ b/src/Collision.hpp
@@ -52,9 +52,7 @@ namespace Vigilant {
 			//}
 
             static void checkProjectileEntityCollision(Entity* projectile, const std::vector<Entity*> entities) {
-            	// TODO: implement
-            	// Sane as playerEntityCollision but need to call event not for entity, but ENtity* shooter
-            	// Or another event?
+            	// Sane as playerEntityCollision but need to call event not for entity, but Entity* shooter
 				// This is tempporary because lua wont know if player collided with entity or players projectile
 				// Also npcs will not be able to create projectiles themselves
 				Entity* owner = projectile->getComponent<ProjectileComponent>()->getShooter();
@@ -67,10 +65,9 @@ namespace Vigilant {
 				};
 
                 for (auto &entity : entities) {
-                	auto isProjectile = entity->getComponent<ProjectileComponent>();
-                	auto isPlayer = entity->getComponent<InputComponent>();
-                	if (isProjectile || isPlayer)
-                		continue;
+                    // Projectile won't collide with other projectiles or player for now
+                    if (entity->hasComponent<ProjectileComponent>() || entity->hasComponent<InputComponent>())
+                        continue;
 
                 	auto entityCollider = entity->getComponent<ColliderComponent>();
                 	auto entitySprite = entity->getComponent<SpriteComponent>();
@@ -101,14 +98,13 @@ namespace Vigilant {
 				auto playerSprite = player->getComponent<SpriteComponent>();
 
                 for (auto &entity : entities) {
+                    // Player won't collide with himself or any projectiles for now
+                    if(entity->hasComponent<InputComponent>() || entity->hasComponent<ProjectileComponent>())
+                        continue;
+
 					auto collider = entity->getComponent<ColliderComponent>();
 					auto sprite = entity->getComponent<SpriteComponent>();
-					auto isPlayer = entity->getComponent<InputComponent>();
-					auto projectile = entity->getComponent<ProjectileComponent>();
-					// For now player will not colide wiht projectiles
-					if (isPlayer || projectile) {
-						continue;
-					}
+
 					if (collider && sprite) {
 						// BROAD PHASE
 						// Try to dismiss some entities earlier for performance?

--- a/src/Component.hpp
+++ b/src/Component.hpp
@@ -1,20 +1,51 @@
 #ifndef __Component__
 #define __Component__
 
+#include <memory>
+#include <bitset>
+#include <array>
+
 namespace Vigilant {
 
     class Entity;
+    class Component;
+
+    using ComponentID = std::size_t;
+
+    inline ComponentID getComponentTypeID() {
+        static ComponentID lastID = 0;
+        return lastID++;
+    }
+
+    // Makes sure each component has a unique id associated to it, so it should be:
+    // Id - 0, Transform = 1 and so on
+    template <typename T> inline getComponentTypeID() noexcept {
+        static ComponentID typeID = getComponentTypeID();
+        return typeID;
+    }
+
+    // 2022-12-16: current component count - 9
+    constexpr std::size_t MAX_COMPONENTS = 32;
+
+    // Will allow to get component without looping dynamic arrays and dynamic_cast
+    using ComponentBitSet = std::bitset<MAX_COMPONENTS>;
+    using ComponentArray = std::array<Component*, MAX_COMPONENTS>;
+
 
     /**
      * Different from traditional ECS model where components only hold data, here we will provide data and functionality
      */
     class Component {
         public:
+            // TODO: move load params to constructor? To utilise TArgs thingy
             Component(Entity* owner): owner(owner) {}
+            virtual ~Component(){}
 
+            virtual void init() {}
             virtual void preUpdate(float deltaTime) {}
             virtual void update(float deltaTime) {}
             virtual void render() {}
+
         protected:
             Entity* owner;
     };

--- a/src/Entity.hpp
+++ b/src/Entity.hpp
@@ -31,15 +31,14 @@ namespace Vigilant {
 			}
 
 			virtual void update(float deltaTime) {
-				// or for (auto& c: components)
-				for(int i = components.size() - 1; i >= 0; i--) {
-					components[i]->preUpdate(deltaTime);
-					components[i]->update(deltaTime);
+				for (auto& c: components) {
+					c->preUpdate(deltaTime);
+					c->update(deltaTime);
 				}
 			}
 			virtual void draw(float deltaTime) {
-				for(int i = components.size() - 1; i >= 0; i--) {
-					components[i]->render();
+				for (auto& c: components) {
+					c->render();
 				}
 			}
 			// Deprecated

--- a/src/Entity.hpp
+++ b/src/Entity.hpp
@@ -4,39 +4,34 @@
 #include <vector>
 #include <memory>
 
-#include "LoaderParams.hpp"
-
 #include "Component.hpp"
 #include "TransformComponent.hpp"
 #include "IdComponent.hpp"
 
-#include "SpriteComponent.hpp"
-#include "InputComponent.hpp"
-#include "PhysicsComponent.hpp"
-#include "ColliderComponent.hpp"
-
 #include "Logger.hpp"
-#include "LuaScript.hpp"
-
-// Temp for testing
-#include <iostream>
+#include "LoaderParams.hpp"
 
 namespace Vigilant {
 	/** \brief Entity
 	*
 	*  Different from traditional ECS model where Entity is basically just a number
-	*  TODO: Future plans: Implement Entity Component System to decouple things like Renderer, Audio and so on
+	*  TODO: Future plans:
+	*	* Implement systems and system signatures
+	*   * Implement render groups
+	*   * Clenup older code
 	*/
 	class Entity {
 
 		public:
             Entity() {
+				// Init component array for safety
+				for (auto& c: componentArray) { c = nullptr; }
 				id = addComponent<IdComponent>();
 				transform = addComponent<TransformComponent>();
-				alive = true;
 			}
 
 			virtual void update(float deltaTime) {
+				// or for (auto& c: components)
 				for(int i = components.size() - 1; i >= 0; i--) {
 					components[i]->preUpdate(deltaTime);
 					components[i]->update(deltaTime);
@@ -47,55 +42,102 @@ namespace Vigilant {
 					components[i]->render();
 				}
 			}
+			// Deprecated
             virtual void clean() {}
-
+			// Deprecated
 			virtual void load(const LoaderParams *params) {}
 
 			void destroy() {
 				alive = false;
 			}
 
+			template <typename T> bool hasComponent() const {
+				return componentBitset[getComponentTypeID<T>()];
+			}
+
+			//template <typename T, typename... TArgs>
+			//T& addComponent(TArgs&&... mArgs) {
+				//T* c(new T(std::forward<TArgs>(mArgs)...));
+				//c->owner = this // need to rename owner to entity
+				//	std::shared_ptr<Component> newComponent = std::make_shared<T>(this);
+				//components.emplace_back(std::move(newComponent));
+
+				//componentArray[getComponentTypeID<T>()] = c;
+				//componentBitset[getComponentTypeID<T>()] = true;
+				//
+				//c->init();
+				//
+				//return *c;
+			//}
+
 			template <typename T>
-			std::shared_ptr<T> addComponent() {
+			T* addComponent() {
+			// std::shared_ptr<T> addComponent() {
 				if (!std::is_base_of<Component, T>::value) {
 					Logger::Instance()->error("Must derive from Component class!");
 				}
 
-				// Checks if there is already a component of this type
-				for (auto& component: components) {
-					if (std::dynamic_pointer_cast<T>(component)) {
-						return std::dynamic_pointer_cast<T>(component);
-					}
+				if (hasComponent<T>()) {
+					return getComponent<T>();
 				}
+				// Checks if there is already a component of this type
+				//for (auto& component: components) {
+					//if (std::dynamic_pointer_cast<T>(component)) {
+						//return std::dynamic_pointer_cast<T>(component);
+					//}
+				//}
 
 				std::shared_ptr<T> newComponent = std::make_shared<T>(this);
 				components.push_back(newComponent);
 
-				return newComponent;
+				// TODO: do I need to use unique_ptr here? Because shared_ptr will create a copy
+				// Seems to actually work at the moment
+				// So do I even need std::vector for components at this point
+				componentArray[getComponentTypeID<T>()] = newComponent.get();
+				componentBitset[getComponentTypeID<T>()] = true;
+
+				newComponent->init();
+
+				return newComponent.get();
 			}
 
-			template <typename T>
-			std::shared_ptr<T> getComponent() {
-				for (auto& component: components) {
-					if (std::dynamic_pointer_cast<T>(component)) {
-						return std::dynamic_pointer_cast<T>(component);
-					}
-				}
-				return nullptr;
+			//template <typename T> T& getComponent() {
+				//auto ptr(componentArray[getComponentTypeID<T>()]);
+				//return *static_cast<T*>(ptr);
+			//}
+
+			template <typename T> T* getComponent() {
+				auto ptr(componentArray[getComponentTypeID<T>()]);
+				if (ptr != nullptr)
+					return static_cast<T*>(ptr);
+				else
+					return nullptr;
 			}
+
+			// template <typename T>
+			// std::shared_ptr<T> getComponent() {
+			// 	for (auto& component: components) {
+			// 		if (std::dynamic_pointer_cast<T>(component)) {
+			// 			return std::dynamic_pointer_cast<T>(component);
+			// 		}
+			// 	}
+			// 	return nullptr;
+			// }
 
 			bool isAlive() { return alive; }
 
-			std::shared_ptr<TransformComponent> transform;
-			std::shared_ptr<IdComponent> id;
+			// std::shared_ptr<TransformComponent> transform;
+			// std::shared_ptr<IdComponent> id;
+			TransformComponent* transform;
+			IdComponent* id;
 
-			~Entity(){
-				std::cout << "Entity destructor called." << std::endl;
-			}
+			~Entity(){}
 		private:
-
 			std::vector<std::shared_ptr<Component>> components;
-			bool alive;
+			bool alive = true;
+
+			ComponentArray componentArray;
+			ComponentBitSet componentBitset;
 	};
 }
 

--- a/src/ScriptEngine.hpp
+++ b/src/ScriptEngine.hpp
@@ -4,7 +4,12 @@
 #include "LuaScript.hpp"
 
 #include "Entity.hpp"
+
+#include "SpriteComponent.hpp"
+#include "PhysicsComponent.hpp"
 #include "ProjectileComponent.hpp"
+#include "ColliderComponent.hpp"
+#include "InputComponent.hpp"
 #include "ButtonComponent.hpp"
 #include "UILabelComponent.hpp"
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -112,4 +112,7 @@ namespace Vigilant {
 		}
 	}
 
+	void Window::setWindowTitle(const char* title) {
+		SDL_SetWindowTitle(m_pWindow, title);
+	}
 }

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -56,6 +56,7 @@ namespace Vigilant {
 			SDL_Window* getSDLWindow() { return m_pWindow; } ///< SDL_Window pointer getter
 			SDL_Renderer* getSDLRenderer() { return renderer; } ///<Optional SDL_Renderer getter
 			void setSDLRendering(bool sdlRenderingEnabled) { GLContextEnabled =  !sdlRenderingEnabled; }
+			void setWindowTitle(const char* title);
 
 		private:
 


### PR DESCRIPTION
Implementing ComponentBitSet and ComponentArray, 

Entity now can use bit set to quickly asses if component exists
and component array to quickly get the component, 
for now std::vector will still be used for iteration of components and I left some code related to shared_ptr for the future work.
As an extra: added FPS display for main window, performance issue identified: onCollide() event fires too many times and because of this too many particle emitters are fired which causes massive FPS Drop